### PR TITLE
FIX: Check whether ignore_server str is empty

### DIFF
--- a/src/speedtest_config.rs
+++ b/src/speedtest_config.rs
@@ -84,6 +84,7 @@ impl SpeedTestConfig {
             .attribute("ignoreids")
             .ok_or(Error::ConfigParseError)?
             .split(',')
+            .filter(|s| s.len() != 0)
             .map(|s| s.parse::<u32>())
             .collect::<Result<Vec<u32>, _>>()?;
 

--- a/src/speedtest_config.rs
+++ b/src/speedtest_config.rs
@@ -84,7 +84,7 @@ impl SpeedTestConfig {
             .attribute("ignoreids")
             .ok_or(Error::ConfigParseError)?
             .split(',')
-            .filter(|s| s.len() != 0)
+            .filter(|s| !s.is_empty())
             .map(|s| s.parse::<u32>())
             .collect::<Result<Vec<u32>, _>>()?;
 


### PR DESCRIPTION
Recently I found that there was an error of `Error: ParseIntError(ParseIntError {kind: Empty })` when running this project. Because there is an empty string in `ignore_servers`. It would be an honor if it can be merged.