### PR TITLE
Add fancy errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +71,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -131,6 +161,33 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
 ]
 
 [[package]]
@@ -248,7 +305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -265,7 +322,7 @@ checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -338,7 +395,17 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -438,6 +505,12 @@ dependencies = [
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "h2"
@@ -613,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,10 +915,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.1"
+name = "object"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
@@ -855,7 +952,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -876,6 +973,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "percent-encoding"
@@ -916,7 +1019,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -933,18 +1036,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1105,6 +1208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustix"
 version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,7 +1325,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1255,6 +1364,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1397,7 @@ version = "0.1.4"
 dependencies = [
  "chrono",
  "clap",
+ "color-eyre",
  "csv",
  "env_logger",
  "iter-read",
@@ -1289,6 +1408,7 @@ dependencies = [
  "reqwest",
  "roxmltree",
  "serde",
+ "thiserror",
  "url",
 ]
 
@@ -1309,6 +1429,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1344,6 +1475,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1448,6 +1609,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1499,6 +1682,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -1567,7 +1756,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1601,7 +1790,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ serde = { version = "1.0.114", features = ["derive"] }
 roxmltree = "0.13.0"
 rayon = "1.3.1"
 iter-read = "0.3.0"
+color-eyre = "0.6.2"
+thiserror = "1.0.56"
 
 [dependencies.reqwest]
 version = "0.11.14"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,35 @@
-#[derive(Debug)]
+use thiserror::Error;
+#[derive(Debug, Error)]
 pub enum SpeedTestError {
+    #[error("Reqwest error: {0}")]
     Reqwest(reqwest::Error),
+    #[error("Io error: {0}")]
     Io(::std::io::Error),
+    #[error("Csv error: {0}")]
     Csv(csv::Error),
+    #[error("ParseFloatError error: {0}")]
     ParseFloatError(std::num::ParseFloatError),
+    #[error("ParseIntError error: {0}")]
     ParseIntError(std::num::ParseIntError),
+    #[error("AddrParseError error: {0}")]
     AddrParseError(std::net::AddrParseError),
+    #[error("RoXmlTreeError error: {0}")]
     RoXmlTreeError(roxmltree::Error),
+    #[error("ConfigParseError error")]
     ConfigParseError,
+    #[error("ServerParseError error")]
     ServerParseError,
+    #[error("LatencyTestInvalidPath error")]
     LatencyTestInvalidPath,
+    #[error("LatencyTestClosestError error")]
     LatencyTestClosestError,
+    #[error("UrlParseError error: {0}")]
     UrlParseError(url::ParseError),
+    #[error("SystemTimeError error: {0}")]
     SystemTimeError(std::time::SystemTimeError),
+    #[error("ParseShareUrlError error")]
     ParseShareUrlError,
+    #[error("ThreadPoolBuildError error: {0}")]
     ThreadPoolBuildError(rayon::ThreadPoolBuildError),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,8 @@ use log::info;
 use std::io::{self, Write};
 use url::Url;
 
-fn main() -> Result<(), error::SpeedTestError> {
+fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
     env_logger::init();
 
     let matches = App::new("speedtest-rs")

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use color_eyre::Section;
 use log::info;
 use reqwest::blocking::{Body, Client, Request, Response};
 use reqwest::header::{HeaderValue, CONNECTION, CONTENT_TYPE, REFERER, USER_AGENT};
@@ -44,7 +45,8 @@ pub fn download_configuration() -> color_eyre::Result<Response> {
         .get(url)
         .header(CONNECTION, "close")
         .header(USER_AGENT, ST_USER_AGENT.to_owned())
-        .send()?;
+        .send()
+        .suggestion("Connect to the internet")?;
     info!("Downloaded Configuration from speedtest.net");
     Ok(res)
 }

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -30,7 +30,7 @@ pub struct SpeedTestServer {
     pub url: String,
 }
 
-pub fn download_configuration() -> Result<Response, SpeedTestError> {
+pub fn download_configuration() -> color_eyre::Result<Response> {
     info!("Downloading Configuration from speedtest.net");
 
     #[cfg(not(test))]
@@ -49,7 +49,7 @@ pub fn download_configuration() -> Result<Response, SpeedTestError> {
     Ok(res)
 }
 
-pub fn get_configuration() -> Result<SpeedTestConfig, SpeedTestError> {
+pub fn get_configuration() -> color_eyre::Result<SpeedTestConfig> {
     let config_body = download_configuration()?;
     info!("Parsing Configuration");
     let spt_config = SpeedTestConfig::parse(&(config_body.text()?))?;
@@ -57,7 +57,7 @@ pub fn get_configuration() -> Result<SpeedTestConfig, SpeedTestError> {
     Ok(spt_config)
 }
 
-pub fn download_server_list() -> Result<Response, SpeedTestError> {
+pub fn download_server_list() -> color_eyre::Result<Response> {
     info!("Download Server List");
     #[cfg(not(test))]
     let url = "http://www.speedtest.net/speedtest-servers.php";
@@ -76,7 +76,7 @@ pub fn download_server_list() -> Result<Response, SpeedTestError> {
 
 pub fn get_server_list_with_config(
     config: &SpeedTestConfig,
-) -> Result<SpeedTestServersConfig, SpeedTestError> {
+) -> color_eyre::Result<SpeedTestServersConfig> {
     let config_body = download_server_list()?;
     info!("Parsing Server List");
     let server_config_string = config_body.text()?;

--- a/src/speedtest_servers_config.rs
+++ b/src/speedtest_servers_config.rs
@@ -10,7 +10,7 @@ impl SpeedTestServersConfig {
     pub fn parse_with_config(
         server_config_xml: &str,
         config: &SpeedTestConfig,
-    ) -> Result<SpeedTestServersConfig, SpeedTestError> {
+    ) -> color_eyre::Result<SpeedTestServersConfig> {
         let document = roxmltree::Document::parse(server_config_xml)?;
         let servers = document
             .descendants()


### PR DESCRIPTION
Fixes #142, maybe #124?

Adds colored errors, mostly to clean up how the offline error is displayed. These do not apply to Clap errors.

Since this adds color_eyre and errors are always returned, the new error parsing may be able to replace the entire error module. I have decided not to do that to make fewer changes for this pull request.

This adds `color_eyre` and `thiserror`.

Before:

![image](https://github.com/nelsonjchen/speedtest-rs/assets/109556932/314a1654-bc21-49c8-9bc9-c9dcd37f42ac)

After:

![image](https://github.com/nelsonjchen/speedtest-rs/assets/109556932/46b4ce92-c15b-436a-af59-98f0be5b6955)
